### PR TITLE
File locking mechanism tests

### DIFF
--- a/file-store/pom.xml
+++ b/file-store/pom.xml
@@ -28,6 +28,14 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/file-store/src/main/java/org/keycloak/models/map/storage/file/lock/FileLockManager.java
+++ b/file-store/src/main/java/org/keycloak/models/map/storage/file/lock/FileLockManager.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.file.lock;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
+
+/**
+ * A locking mechanism based on temporary files. A thread owns the lock if it successfully creates the lock file. If the lock
+ * file already exists, the thread retries the operation until it either obtains the lock or the time limit is reached.
+ * Upon completing its task, the thread releases the lock by deleting the corresponding lock file.
+ */
+public class FileLockManager {
+
+    private static final Logger LOG = Logger.getLogger(FileLockManager.class);
+
+    private static final Path locksDir = Path.of("/tmp/.locks/");
+
+    private static final ThreadLocal<List<String>> lockedFiles = new ThreadLocal<>();
+
+    static {
+        if (!Files.exists(locksDir)) {
+            try {
+                Files.createDirectory(locksDir);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static void acquireLockForFile(String fileName, Duration timeout) {
+        long maximumTime = Time.currentTimeMillis() + timeout.toMillis();
+
+        List<String> threadLockedFiles = lockedFiles.get();
+        if (threadLockedFiles != null && threadLockedFiles.contains(fileName)) {
+            LOG.debugf("%s already holds lock for file %s", Thread.currentThread().getName(), fileName);
+            return;
+        }
+
+        int iteration = 0;
+        while (true) {
+            if (Time.currentTimeMillis() >= maximumTime) {
+                throw new RuntimeException("Unable to acquire lock for file " + fileName);
+            }
+            try {
+                Path filePath = Files.createFile(locksDir.resolve(fileName + ".lock"));
+                LOG.debugf("%s successfully acquired lock for file %s", Thread.currentThread().getName(), fileName);
+                if (lockedFiles.get() == null)
+                    lockedFiles.set(new ArrayList<>());
+                lockedFiles.get().add(fileName);
+                break;
+            } catch (IOException e) {
+                iteration++;
+                try {
+                    int delay = computeBackoffInterval(50, iteration);
+                    LOG.debugf("%s failed to create lock file in attempt %d, sleeping for %d millis", Thread.currentThread().getName(), iteration, delay);
+                    Thread.sleep(delay);
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public static void acquireLockForFiles(List<String> files, Duration timeout) {
+        // remove from the list the files for which the thread already has a lock
+        List<String> threadLockedFiles = lockedFiles.get();
+        List<String> toBeLocked = files.stream()
+                .filter(file -> threadLockedFiles == null || !threadLockedFiles.contains(file))
+                .collect(Collectors.toList());
+
+        if (toBeLocked.isEmpty()) {
+            LOG.debugf("%s already holds locks for all the files");
+            return;
+        }
+
+        long maximumTime = Time.currentTimeMillis() + timeout.toMillis();
+        List<String> successfullyLocked = new ArrayList<>();
+        int iteration = 0;
+        while (true) {
+            if (Time.currentTimeMillis() >= maximumTime) {
+                throw new RuntimeException("Unable to acquire lock for all files");
+            }
+            try {
+                for (String file : toBeLocked) {
+                    Path filePath = Files.createFile(locksDir.resolve(file + ".lock"));
+                    successfullyLocked.add(file);
+                }
+                // no exceptions thrown - all locks were successfully acquired
+                if (lockedFiles.get() == null)
+                    lockedFiles.set(new ArrayList<>());
+                lockedFiles.get().addAll(successfullyLocked);
+                LOG.debugf("%s successfully acquired lock for files %s", Thread.currentThread().getName(), successfullyLocked);
+
+                break;
+            } catch (IOException e) {
+                // clear any locks that were acquired in this attempt.
+                successfullyLocked.forEach(file -> {
+                    try {
+                        Files.delete(locksDir.resolve(file + ".lock"));
+                    } catch (IOException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                });
+                successfullyLocked.clear();
+                iteration++;
+                try {
+                    int delay = computeBackoffInterval(50, iteration);
+                    LOG.debugf("%s failed to create lock files in attempt %d, sleeping for %d millis", Thread.currentThread().getName(), iteration, delay);
+                    Thread.sleep(delay);
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+    private static int computeBackoffInterval(int base, int iteration) {
+        int bound = base * (1 << iteration);
+        return new Random().nextInt(bound);
+    }
+
+    public static void releaseLockForFile(String fileName) {
+        if (lockedFiles.get() == null || !lockedFiles.get().contains(fileName)) {
+            throw new RuntimeException(Thread.currentThread().getName() + " is not current holder of lock for file " + fileName);
+        }
+        try {
+            Path filePath = locksDir.resolve(fileName + ".lock");
+            if (Files.exists(filePath))
+                Files.delete(filePath);
+            lockedFiles.get().remove(fileName);
+            LOG.debugf("%s successfully released lock for file %s", Thread.currentThread().getName(), filePath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void releaseLockForFiles(List<String> files) {
+        for (String file : files) {
+            if (lockedFiles.get() == null || !lockedFiles.get().contains(file)) {
+                throw new RuntimeException(Thread.currentThread().getName() + " is not current holder of lock for file " + file);
+            }
+        }
+        // now we know the thread holds all locks, proceed to remove them.
+        try {
+            for (String fileName : files) {
+                Path filePath = locksDir.resolve(fileName + ".lock");
+                if (Files.exists(filePath))
+                    Files.delete(filePath);
+                lockedFiles.get().remove(fileName);
+            }
+            LOG.debugf("%s successfully released lock for files %s", Thread.currentThread().getName(), files);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void releaseAllLocks() {
+        try {
+            // if we have locks structured in sub-directories (e.g. by realm), we can use Files.walk() to visit them all.
+            Files.list(locksDir).filter(file -> !Files.isDirectory(file)).forEach(file -> {
+                try {
+                    Files.delete(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/FileLockTest.java
+++ b/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/FileLockTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.file.lock;
+
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class FileLockTest {
+
+    private TestEntity entity;
+    private static TestFileStore store = new TestFileStore();
+
+    @AfterAll()
+    public static void afterAll() {
+        store.clearStorage();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        FileLockManager.releaseAllLocks();
+        // create a test entity in the store
+        this.entity = new TestEntity("jduke");
+        store.writeEntity(this.entity);
+    }
+
+    // tests for the file locking mechanism
+
+    @Test
+    public void concurrentLockingTest() {
+        final String FILE_NAME = "testFileName";
+
+        AtomicInteger counter = new AtomicInteger();
+        int numIterations = 50;
+        Random rand = new Random();
+        List<Integer> resultingList = new LinkedList<>();
+
+        IntStream.range(0, numIterations).parallel().forEach(index -> {
+
+                FileLockManager.acquireLockForFile(FILE_NAME, Duration.ofSeconds(30));
+
+                // Locked block
+                int c = counter.getAndIncrement();
+
+                try {
+                    Thread.sleep(rand.nextInt(100));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+
+                resultingList.add(c);
+
+                FileLockManager.releaseLockForFile(FILE_NAME);
+            });
+
+        assertThat(resultingList, hasSize(numIterations));
+        assertThat(resultingList, equalTo(IntStream.range(0, 50).boxed().collect(Collectors.toList())));
+    }
+
+    @Test
+    public void lockTimeoutExceptionTest() {
+        final String LOCK_NAME = "lockTimeoutExceptionTestLock";
+        AtomicInteger counter = new AtomicInteger();
+        CountDownLatch waitForTheOtherThreadToFail = new CountDownLatch(1);
+
+        IntStream.range(0, 2).parallel().forEach(index -> {
+
+            try {
+                    FileLockManager.acquireLockForFile(LOCK_NAME, Duration.ofSeconds(2));
+
+                    int c = counter.incrementAndGet();
+                    if (c == 1) {
+                        try {
+                            waitForTheOtherThreadToFail.await();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else {
+                        throw new RuntimeException("Lock acquired by more than one thread.");
+                    }
+
+                    FileLockManager.releaseLockForFile(LOCK_NAME);
+            } catch (RuntimeException e) {
+                int c = counter.incrementAndGet();
+                if (c != 2) {
+                    throw new RuntimeException("Acquiring lock failed by different thread than second.");
+                }
+
+                assertThat(e.getMessage(), containsString("Unable to acquire lock for file " + LOCK_NAME));
+                waitForTheOtherThreadToFail.countDown();
+            }
+        });
+    }
+
+    @Test
+    public void testReleaseAllLocksMethod() throws InterruptedException {
+        final int NUMBER_OF_THREADS = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+        CountDownLatch locksAcquired = new CountDownLatch(NUMBER_OF_THREADS);
+        CountDownLatch testFinished = new CountDownLatch(1);
+
+        try {
+            // Acquire locks and let the threads wait until the end of this test method
+            executor.submit(() -> {
+                IntStream.range(0, NUMBER_OF_THREADS).parallel().forEach(i -> {
+
+                    FileLockManager.acquireLockForFile("FILE_" + i, Duration.ofSeconds(1));
+
+                    locksAcquired.countDown();
+                    try {
+                        testFinished.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+
+                    FileLockManager.releaseLockForFile("FILE_" + i);
+                });
+            });
+
+            locksAcquired.await();
+
+            // Test no lock can be acquired because all are still hold by the executor above
+            AtomicInteger counter = new AtomicInteger();
+            IntStream.range(0, NUMBER_OF_THREADS).parallel().forEach(i -> {
+                        try {
+                            FileLockManager.acquireLockForFile("FILE_" + i, Duration.ofSeconds(1));
+                            throw new RuntimeException("Acquiring lock should not succeed as it was acquired in the first transaction");
+                        } catch (RuntimeException e) {
+                            counter.incrementAndGet();
+                        }
+                    });
+            assertThat(counter.get(), Matchers.equalTo(NUMBER_OF_THREADS));
+
+            FileLockManager.releaseAllLocks();
+
+            // Test all locks can be acquired again
+            counter.set(0);
+            IntStream.range(0, NUMBER_OF_THREADS).parallel().forEach(i -> {
+                        FileLockManager.acquireLockForFile("FILE_" + i, Duration.ofSeconds(1));
+                        counter.incrementAndGet();
+                        FileLockManager.releaseLockForFile("FILE_" + i);
+                    });
+            assertThat(counter.get(), Matchers.equalTo(NUMBER_OF_THREADS));
+        } finally {
+            testFinished.countDown();
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void concurrentLockingMultipleFilesTest() {
+        final List<String> filenames = IntStream.range(0, 10).mapToObj(i -> "FILE_" + i).collect(Collectors.toList());
+
+        AtomicInteger counter = new AtomicInteger();
+        int numIterations = 50;
+        Random rand = new Random();
+        List<Integer> resultingList = new LinkedList<>();
+
+        IntStream.range(0, numIterations).parallel().forEach(index -> {
+
+            FileLockManager.acquireLockForFiles(filenames, Duration.ofSeconds(30));
+
+            // Locked block
+            int c = counter.getAndIncrement();
+
+            try {
+                Thread.sleep(rand.nextInt(100));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+
+            resultingList.add(c);
+
+            FileLockManager.releaseLockForFiles(filenames);
+        });
+
+        assertThat(resultingList, hasSize(numIterations));
+        assertThat(resultingList, equalTo(IntStream.range(0, 50).boxed().collect(Collectors.toList())));
+    }
+
+    @Test
+    public void lockTimeoutExceptionMultipleFilesTest() throws Exception {
+        final List<String> filenames = IntStream.range(0, 10).mapToObj(i -> "FILE_" + i).collect(Collectors.toList());
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // main thread acquires lock for one of the files
+        FileLockManager.acquireLockForFile("FILE_1", Duration.ofSeconds(1));
+
+        // spawn a different thread that will attempt to acquire locks for all files
+        new Thread(() -> {
+            try {
+                FileLockManager.acquireLockForFiles(filenames, Duration.ofSeconds(2));
+                throw new RuntimeException("Acquiring lock should not succeed as one file was locked by main transaction");
+            } catch(RuntimeException re) {
+                latch.countDown();
+                assertThat(re.getMessage(), containsString("Unable to acquire lock for all files"));
+            }
+        }).start();
+
+        latch.await(5, TimeUnit.SECONDS);
+        FileLockManager.releaseLockForFile("FILE_1");
+    }
+
+    // tests showcasing the file lock mechanism in the context of a store that reads/writes entities from/to files.
+
+    @Test
+    public void testWriteBeforeReadingStream() throws Exception {
+        CountDownLatch inputStreamReady = new CountDownLatch(1);
+        CountDownLatch writeConcluded = new CountDownLatch(1);
+
+        new Thread(() -> {
+            ReadResult result = store.getInputStreamAndModifiedTime(entity.getId());
+            inputStreamReady.countDown();
+            try {
+                // wait until writing is finished.
+                writeConcluded.await();
+
+                // finish reading the entity with the previously obtained stream and check that the name still matches the old name.
+                TestEntity testEntity = store.readEntity(result);
+                assertThat(testEntity.getName(), equalTo("jduke"));
+
+                // reading entity again (i.e. with a new input stream) should yield the updated entity name.
+                testEntity = store.readEntity(entity.getId());
+                assertThat(testEntity.getName(), equalTo("theduke"));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);            }
+        }).start();
+
+        // wait until input stream for file representing the entity is obtained.
+        inputStreamReady.await();
+
+        // read the entity again to refresh the state (i.e. load version) and then change the name and write it back.
+        TestEntity testEntity = store.readEntity(entity.getId());
+        testEntity.setName("theduke");
+        store.writeEntity(testEntity);
+        writeConcluded.countDown();
+    }
+
+    @Test
+    public void testWriteOutdatedEntity() throws Exception {
+        CountDownLatch readPerformed = new CountDownLatch(1);
+        CountDownLatch mainLatch = new CountDownLatch(1);
+
+        new Thread(() -> {
+            TestEntity testEntity = store.readEntity(entity.getId());
+            readPerformed.countDown();
+            try {
+                // wait until main finishes.
+                mainLatch.await();
+
+                // change the entity we've read and attempt to write it.
+                testEntity.setName("anotherduke");
+                store.writeEntity(testEntity);
+            } catch (RuntimeException re) {
+                assertThat(re.getMessage(), equalTo("Entity with id " + testEntity.getId() + " was changed"));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }).start();
+
+        // wait until the other thread reads the entity.
+        readPerformed.await();
+
+        // read the entity again to refresh the state (i.e. load version) and then change the name and write it back.
+        TestEntity testEntity = store.readEntity(entity.getId());
+        testEntity.setName("theduke");
+        store.writeEntity(testEntity);
+        mainLatch.countDown();
+    }
+
+    @Test
+    public void testWriteDeletedEntity() throws Exception {
+        CountDownLatch readPerformed = new CountDownLatch(1);
+        CountDownLatch mainLatch = new CountDownLatch(1);
+
+        new Thread(() -> {
+            TestEntity testEntity = store.readEntity(entity.getId());
+            readPerformed.countDown();
+            try {
+                // wait until main finishes.
+                mainLatch.await();
+
+                // change the entity we've read and attempt to write it.
+                testEntity.setName("anotherduke");
+                store.writeEntity(testEntity);
+            } catch (RuntimeException re) {
+                assertThat(re.getMessage(), equalTo("Entity with id " + testEntity.getId() + " was removed"));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }).start();
+
+        // wait until the other thread reads the entity.
+        readPerformed.await();
+
+        // delete the entity.
+        store.deleteEntity(entity);
+    }
+
+    @Test
+    public void testWriteDuplicateEntity() {
+        // attempt to create an entity with the same id as the test entity
+        TestEntity anotherEntity = new TestEntity("anotherduke", UUID.fromString(entity.getId()));
+        try {
+            store.writeEntity(anotherEntity);
+        } catch(RuntimeException re) {
+            assertThat(re.getMessage(), equalTo("Entity with id " + anotherEntity.getId() + " already exists"));
+        }
+    }
+}
+

--- a/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/TestEntity.java
+++ b/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/TestEntity.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.file.lock;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * A simple test entity that is meant to be stored in its serialized form. The version is set to the file's last modified time.
+ */
+public class TestEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient long version;
+
+    private UUID id;
+
+    private String name;
+
+    public TestEntity(final String name) {
+        this(name, UUID.randomUUID());
+    }
+
+    public TestEntity(final String name, final UUID id) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return this.id.toString();
+    }
+
+    public long getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "TestEntity, id=" + id + ", name=" + name + ", version=" + version;
+    }
+}

--- a/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/TestFileStore.java
+++ b/file-store/src/test/java/org/keycloak/models/map/storage/file/lock/TestFileStore.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.file.lock;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A simple file-based store that relies on the file locking mechanism to safely read/write entities from/to files.
+ */
+public class TestFileStore {
+
+    private static final Logger LOG = Logger.getLogger(TestFileStore.class);
+
+    private final Path storageDir = Path.of("/tmp/storage/");
+
+    public TestFileStore() {
+        if (!Files.exists(storageDir)) {
+            try {
+                Files.createDirectory(storageDir);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Convenience method that performs all steps involved in reading an entity.
+     *
+     * @param id the id of the entity to be read.
+     * @return the {@link TestEntity} that was read, or {@code null} if no entity with the given id is found.
+     */
+    public TestEntity readEntity(String id) {
+        ReadResult result = getInputStreamAndModifiedTime(id);
+        return readEntity(result);
+    }
+
+    /**
+     * Obtains the object input stream for the file containing the entity identified by the given id, along with the file's
+     * last modified time. This operation is controlled by a file lock, so reading operations acquire the lock and release
+     * it as soon as it obtains the stream it needs to read the object from. The actual reading is not controlled by the lock.
+     *
+     * This is done to minimize the amount of time the lock is employed. As soon as a stream is obtained, the thread can
+     * read the file's contents even if in the meantime another thread writes to the file.
+     *
+     * @param entityId the id of the entity being read.
+     * @return a {@link ReadResult} containing the input stream and last modified time.
+     */
+    public ReadResult getInputStreamAndModifiedTime(String entityId) {
+        String fileName = entityId + ".kcs";
+        Path filePath = storageDir.resolve(fileName);
+        if (!Files.exists(filePath)) {
+            LOG.debugf("Entity with id %s not found in file storage", entityId);
+            return null;
+        }
+
+        // acquire lock for file representing the entity
+        FileLockManager.acquireLockForFile(fileName, Duration.ofSeconds(5));
+        try {
+            // obtain file metadata to extract the last modified time (used as version in the entity)
+            BasicFileAttributes attr = Files.readAttributes(filePath, BasicFileAttributes.class);
+            long lastModifiedTime = attr.lastModifiedTime().toMillis();
+            // obtain an input stream to read the object
+            ObjectInputStream inputStream = new ObjectInputStream(new FileInputStream(filePath.toString()));
+            return new ReadResult(lastModifiedTime, inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            FileLockManager.releaseLockForFile(fileName);
+        }
+    }
+
+    /**
+     * Reads the entity using the data contained in the specified {@link ReadResult}. This operation is not controlled
+     * by any locks.
+     *
+     * @param readResult the object containing the input stream and last modified time used to read the entity.
+     * @return the {@link TestEntity} that was read.
+     */
+    public TestEntity readEntity(final ReadResult readResult) {
+        // simply read the object from the stream and set the last modified time as its version.
+        try {
+            TestEntity entity = (TestEntity) readResult.getInputStream().readObject();
+            entity.setVersion(readResult.getLastModifiedTime());
+            readResult.getInputStream().close();
+            return entity;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Convenience method that performs all steps involved in persisting an entity.
+     *
+     * @param entity the entity to be written.
+     */
+    public void writeEntity(TestEntity entity) {
+        Path tempFilePath = writeEntityToTempFile(entity);
+        moveTempFileToEntityFile(tempFilePath, entity);
+    }
+
+    /**
+     * Writes the specified entity to a temporary file. This operation is not controlled by any locks.
+     *
+     * @param entity the entity to be written.
+     * @return the {@link Path} to the temporary file.
+     */
+    public Path writeEntityToTempFile(final TestEntity entity) {
+        Path tempFilePath = storageDir.resolve(UUID.randomUUID() + ".tmp");
+        try {
+            // check if the entity is in a valid state. If not, do not waste resources serializing an entity that
+            // cannot be written to the store.
+            checkIsSafeToWrite(entity);
+            // write the entity to a temporary file.
+            ObjectOutputStream stream = new ObjectOutputStream(new FileOutputStream(tempFilePath.toString()));
+            stream.writeObject(entity);
+            stream.close();
+        } catch(IOException e) {
+            throw new RuntimeException(e);
+        }
+        return tempFilePath;
+    }
+
+    /**
+     * Moves the temporary file into the actual file that represents the entity. This operation is controlled by a file lock
+     * to prevent concurrent access to the file that being overridden.
+     *
+     * @param tempFilePath the {@link Path} to the temp file.
+     * @param entity the entity being written.
+     */
+    public void moveTempFileToEntityFile(Path tempFilePath, TestEntity entity) {
+        String entityFileName = entity.getId() + ".kcs";
+        // obtain lock for the file representing the entity.
+        FileLockManager.acquireLockForFile(entityFileName, Duration.ofSeconds(5));
+        try {
+            // check again if entity can be written - this can have changed since the entity was written to the temp file.
+            checkIsSafeToWrite(entity);
+            // move the temporary file into the actual file, then release the lock.
+            Files.move(tempFilePath, storageDir.resolve(entityFileName), StandardCopyOption.ATOMIC_MOVE);
+        } catch (RuntimeException re) {
+            throw re;
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        } finally {
+            // release the lock.
+            FileLockManager.releaseLockForFile(entityFileName);
+        }
+    }
+
+    public void deleteEntity(TestEntity entity) {
+        String fileName = entity.getId() + ".kcs";
+        // acquire lock for file representing the entity
+        FileLockManager.acquireLockForFile(fileName, Duration.ofSeconds(5));
+        // delete the file from the storage
+        try {
+            if (Files.exists(storageDir.resolve(fileName)))
+                Files.delete(storageDir.resolve(fileName));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            // release the lock
+            FileLockManager.releaseLockForFile(fileName);
+        }
+    }
+
+    private void checkIsSafeToWrite(TestEntity entity) {
+        try {
+            Path filePath = storageDir.resolve(entity.getId() + ".kcs");
+            // check the entity's version - if zero, this is a new entity.
+            if (entity.getVersion() == 0) {
+                // if a file already exists with the same id, we have an attempt to create a duplicate entity.
+                if (Files.exists(filePath)) {
+                    throw new RuntimeException("Entity with id " + entity.getId() + " already exists");
+                }
+            } else {
+                // if the file representing the entity doesn't exist anymore, we have a stale entity.
+                if (!Files.exists(filePath)) {
+                    throw new RuntimeException("Entity with id " + entity.getId() + " was removed");
+                }
+                // if the file exists but has a newer modified date, we have a stale entity.
+                BasicFileAttributes attr = Files.readAttributes(filePath, BasicFileAttributes.class);
+                long lastModifiedTime = attr.lastModifiedTime().toMillis();
+                if (entity.getVersion() < lastModifiedTime) {
+                    throw new RuntimeException("Entity with id " + entity.getId() + " was changed");
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Removes all files from the storage.
+     */
+    public void clearStorage() {
+        try {
+            // if we have locks structured in sub-directories (e.g. by realm), we can use Files.walk() to visit them all.
+            Files.list(storageDir).filter(file -> !Files.isDirectory(file)).forEach(file -> {
+                try {
+                    Files.delete(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+class ReadResult {
+
+    private long lastModifiedTime;
+    private ObjectInputStream inputStream;
+
+    public ReadResult(long lastModifiedTime, ObjectInputStream stream) {
+        this.lastModifiedTime = lastModifiedTime;
+        this.inputStream = stream;
+    }
+
+    public long getLastModifiedTime() {
+        return this.lastModifiedTime;
+    }
+
+    public ObjectInputStream getInputStream() {
+        return this.inputStream;
+    }
+}

--- a/no-downtime-upgrade/pom.xml
+++ b/no-downtime-upgrade/pom.xml
@@ -7,7 +7,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         
-        <keycloak.version>11.0.0-SNAPSHOT</keycloak.version>
+        <keycloak.version>999-SNAPSHOT</keycloak.version>
     </properties>
 
     <groupId>org.keycloak.playground</groupId>


### PR DESCRIPTION
A locking mechanism based on temporary files.
- thread that is able to create the temporary file holds the lock
- lock is released once same thread removes said temporary file

PR contains a sample file store that relies on this locking mechanism to read and write objects from/to files
- read threads acquire a lock until they get hold of the input stream from which they can read objects. The lock is released as soon as stream is obtained
- write threads write contents to a random temporary file. Then they acquire the lock to move the file into the original file, and release lock as soon as the file is moved. This shortens the locking window to allow more throughput